### PR TITLE
Add cmath include to Matrix4x4.hpp

### DIFF
--- a/include/BNM/UnityStructures/Matrix4x4.hpp
+++ b/include/BNM/UnityStructures/Matrix4x4.hpp
@@ -5,6 +5,8 @@
 #include "Vector4.hpp"
 #include "Matrix3x3.hpp"
 
+#include <cmath>
+
 #define MAT(m, r, c) (m)[(c)*4+(r)]
 #define RETURN_ZERO do { for (int i=0;i<16;i++) out[i] = 0.0F; return false; } while(0)
 


### PR DESCRIPTION
`<cmath>` is not included in `<vector>` in some of the STL implementations: https://github.com/xmake-io/xmake-repo/actions/runs/18494718294/job/52696175171?pr=8374