### PR TITLE
Fix crash in Internal::Load when onIl2CppLoaded list is empty

### DIFF
--- a/src/Loading.cpp
+++ b/src/Loading.cpp
@@ -34,6 +34,7 @@ void Internal::Load() {
 
     // Call all events after loading il2cpp
     auto events = onIl2CppLoaded;
+    if (events.IsEmpty()) return;
     auto current = events.lastElement->next;
     do {
         current->value();


### PR DESCRIPTION
## Summary
Fixed a crash that occurred in `Internal::Load` when no events were registered in `onIl2CppLoaded`.

## Problem
The `BNM::ForwardList` used for `onIl2CppLoaded` is a circular linked list.
When the list is empty, `lastElement` is `nullptr`. The existing code attempted to access `lastElement->next` without checking if the list was empty, leading to a null pointer dereference and a crash.

## Solution
Added an `IsEmpty()` check before entering the event dispatching loop.
If no events are registered, the function now returns early safely.

## Impact
- Prevents crashes when `AddOnLoadedEvent` has not been called.
- Ensures safe behavior regardless of whether events are registered.
- No negative impact on existing functionality.

## Test
Verified that the application no longer crashes when the event list is empty, and events are still called correctly when registered.